### PR TITLE
Movement speed icons

### DIFF
--- a/src/module/apps/token-panel.js
+++ b/src/module/apps/token-panel.js
@@ -83,6 +83,18 @@ export class TokenPanel extends Application {
             })
         }
 
+        let movement = [];
+        movement.push(
+            {name: "Overland", value: actor.system.capabilities?.overland ?? 0, icon: "fas fa-shoe-prints"},
+            {name: "Swim", value: actor.system.capabilities?.swim ?? 0, icon: "fas fa-swimmer"},
+            {name: "Burrow", value: actor.system.capabilities?.burrow ?? 0, icon: "fas fa-mountain"},
+            {name: "Levitate", value: actor.system.capabilities?.levitate ?? 0, icon: "fas fa-feather"},
+            {name: "Sky", value: actor.system.capabilities?.sky ?? 0, icon: "fab fa-fly"},
+            {name: "Teleporter", value: actor.system.capabilities?.teleporter ?? 0, icon: "fas fa-people-arrows"}
+        );
+
+        movement = movement.filter(item => item.value !== 0);
+
         let heldItem = null;
         if(this.actor.system.heldItem && this.actor.system.heldItem != "None") {
             const item = await game.ptu.item.get(this.actor.system.heldItem, "item");
@@ -107,7 +119,8 @@ export class TokenPanel extends Application {
             effects: actor.itemTypes.effect || [],
             feats,
             abilities,
-            heldItem
+            heldItem,
+            movement
         }
     }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -110,6 +110,14 @@
   overflow-y: hidden;
   overflow-x: auto;
 }
+.token-panel .main-panel .movement {
+  display: flex;
+  flex-direction: column;
+  color: whitesmoke;
+}
+.token-panel .main-panel .movement .movementcard {
+  padding: 5px;
+}
 .token-panel .main-panel .name-tag,
 .token-panel .main-panel .header-toggle {
   writing-mode: vertical-rl;

--- a/static/css/main.less
+++ b/static/css/main.less
@@ -131,6 +131,15 @@
             overflow-x: auto;
         }
 
+        .movement {
+            display: flex;
+            flex-direction: column;
+            color: whitesmoke;
+
+            .movementcard {
+                padding:5px;
+            }
+        }
         .name-tag, .header-toggle {
             writing-mode: vertical-rl;
             transform: rotate(180deg);

--- a/static/templates/apps/token-panel.hbs
+++ b/static/templates/apps/token-panel.hbs
@@ -255,6 +255,12 @@
                 </div>
                 <div class="divider"></div>
             {{/if}}
+            {{#if show.movement}}
+                {{#each movement as |move|}}
+                    <i class="{{move.icon}}" title="{{move.name}}"></i> {{move.value}}
+                {{/each}}
+                <div class="divider"></div>
+            {{/if}}
         </div>
     </div>
     <div class="footer-panel">
@@ -275,6 +281,9 @@
                     <i class="fas fa-backpack" title="Items"></i>
                 </div>
             {{/if}}
+            <div class="action {{# is show.movement}}active{{else}}inactive{{/if}}" data-target="movement">
+                <i class="fas fa-walking" title="Movement"></i>
+            </div>
         </div>
     </div>
 </section>

--- a/static/templates/apps/token-panel.hbs
+++ b/static/templates/apps/token-panel.hbs
@@ -256,9 +256,13 @@
                 <div class="divider"></div>
             {{/if}}
             {{#if show.movement}}
-                {{#each movement as |move|}}
-                    <i class="{{move.icon}}" title="{{move.name}}"></i> {{move.value}}
-                {{/each}}
+                <div class="movement">
+                    {{#each movement as |move|}}
+                        <div class="movementcard">
+                            <i class="{{move.icon}}" title="{{move.name}}"></i> {{move.value}}
+                        </div>
+                    {{/each}}
+                </div>
                 <div class="divider"></div>
             {{/if}}
         </div>
@@ -281,7 +285,7 @@
                     <i class="fas fa-backpack" title="Items"></i>
                 </div>
             {{/if}}
-            <div class="action {{# is show.movement}}active{{else}}inactive{{/if}}" data-target="movement">
+            <div class="action {{#if show.movement}}active{{else}}inactive{{/if}}" data-target="movement">
                 <i class="fas fa-walking" title="Movement"></i>
             </div>
         </div>


### PR DESCRIPTION
movement speed icons now appear in the side panel

![image](https://github.com/pokemon-tabletop-reunited/Foundry-Pokemon-Tabletop-United-System/assets/43385250/9251c7bb-b4e2-408d-9e2c-c4f5b5645f62)
![image](https://github.com/pokemon-tabletop-reunited/Foundry-Pokemon-Tabletop-United-System/assets/43385250/85c05211-6257-40bd-98cb-9c14243532dd)
can be toggled with the walking button